### PR TITLE
Add missing import statement to project 1

### DIFF
--- a/projects/project1/tester.py
+++ b/projects/project1/tester.py
@@ -11,6 +11,7 @@
 # Only the first two tests specify the output. For the next five, you'll need
 # to read the input and work out the output that you should be expecting.
 #
+from project1 import *
 ################################################################################
 #Testing keyword_found
 #


### PR DESCRIPTION
`tester.py` was missing an import from `project1` which prevented a student from just calling `python tester.py`. I added this.